### PR TITLE
chore: update docker hub image tags again

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -40,8 +40,7 @@ jobs:
       - name: Login to Docker Hub Registry
         uses: docker/login-action@v3
         with:
-          registry: registry-1.docker.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Login to GitHub Package Registry

--- a/distributions/githubactions/.goreleaser.yaml
+++ b/distributions/githubactions/.goreleaser.yaml
@@ -62,7 +62,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-386
-        - krzko/otelcol-githubactions:{{ .Version }}-386
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-386
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -79,7 +79,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-amd64
-        - krzko/otelcol-githubactions:{{ .Version }}-amd64
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-amd64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -96,7 +96,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-arm64
-        - krzko/otelcol-githubactions:{{ .Version }}-arm64
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-arm64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -113,7 +113,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-ppc64le
-        - krzko/otelcol-githubactions:{{ .Version }}-ppc64le
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-ppc64le
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -134,10 +134,10 @@ docker_manifests:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-ppc64le
     - name_template: krzko/otelcol-githubactions:{{ .Version }}
       image_templates:
-        - krzko/otelcol-githubactions:{{ .Version }}-386
-        - krzko/otelcol-githubactions:{{ .Version }}-amd64
-        - krzko/otelcol-githubactions:{{ .Version }}-arm64
-        - krzko/otelcol-githubactions:{{ .Version }}-ppc64le
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-386
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-amd64
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-arm64
+        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-ppc64le
 sboms:
     - id: archive
       artifacts: archive

--- a/distributions/gitlab/.goreleaser.yaml
+++ b/distributions/gitlab/.goreleaser.yaml
@@ -62,7 +62,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-386
-        - krzko/otelcol-gitlab:{{ .Version }}-386
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-386
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -79,7 +79,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-amd64
-        - krzko/otelcol-gitlab:{{ .Version }}-amd64
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-amd64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -96,7 +96,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-arm64
-        - krzko/otelcol-gitlab:{{ .Version }}-arm64
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-arm64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -113,7 +113,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-ppc64le
-        - krzko/otelcol-gitlab:{{ .Version }}-ppc64le
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-ppc64le
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -134,10 +134,10 @@ docker_manifests:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-ppc64le
     - name_template: krzko/otelcol-gitlab:{{ .Version }}
       image_templates:
-        - krzko/otelcol-gitlab:{{ .Version }}-386
-        - krzko/otelcol-gitlab:{{ .Version }}-amd64
-        - krzko/otelcol-gitlab:{{ .Version }}-arm64
-        - krzko/otelcol-gitlab:{{ .Version }}-ppc64le
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-386
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-amd64
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-arm64
+        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-ppc64le
 sboms:
     - id: archive
       artifacts: archive

--- a/distributions/googlecloudspanner/.goreleaser.yaml
+++ b/distributions/googlecloudspanner/.goreleaser.yaml
@@ -62,7 +62,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-386
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-386
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-386
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -79,7 +79,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-amd64
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-amd64
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-amd64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -96,7 +96,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-arm64
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-arm64
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-arm64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -113,7 +113,7 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-ppc64le
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-ppc64le
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-ppc64le
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -134,10 +134,10 @@ docker_manifests:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-ppc64le
     - name_template: krzko/otelcol-googlecloudspanner:{{ .Version }}
       image_templates:
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-386
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-amd64
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-arm64
-        - krzko/otelcol-googlecloudspanner:{{ .Version }}-ppc64le
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-386
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-amd64
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-arm64
+        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-ppc64le
 sboms:
     - id: archive
       artifacts: archive


### PR DESCRIPTION
Adding `otelcol-distributions/` to docker hub images