### PR TITLE
fix: githubactions otelcol config and tags

### DIFF
--- a/distributions/githubactions/.goreleaser.yaml
+++ b/distributions/githubactions/.goreleaser.yaml
@@ -62,7 +62,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-386
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-386
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -79,7 +78,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-amd64
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-amd64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -96,7 +94,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-arm64
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-arm64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -113,7 +110,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-ppc64le
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-ppc64le
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -132,12 +128,6 @@ docker_manifests:
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-amd64
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-arm64
         - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-ppc64le
-    - name_template: krzko/otelcol-githubactions:{{ .Version }}
-      image_templates:
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-386
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-amd64
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-arm64
-        - krzko/otelcol-distributions/otelcol-githubactions:{{ .Version }}-ppc64le
 sboms:
     - id: archive
       artifacts: archive

--- a/distributions/githubactions/otelcol.yaml
+++ b/distributions/githubactions/otelcol.yaml
@@ -20,7 +20,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [otlp]
+      receivers: [githubactions]
       processors: []
       exporters: [debug]
 

--- a/distributions/gitlab/.goreleaser.yaml
+++ b/distributions/gitlab/.goreleaser.yaml
@@ -62,7 +62,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-386
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-386
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -79,7 +78,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-amd64
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-amd64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -96,7 +94,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-arm64
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-arm64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -113,7 +110,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-ppc64le
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-ppc64le
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -132,12 +128,6 @@ docker_manifests:
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-amd64
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-arm64
         - ghcr.io/krzko/otelcol-distributions/gitlab:{{ .Version }}-ppc64le
-    - name_template: krzko/otelcol-gitlab:{{ .Version }}
-      image_templates:
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-386
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-amd64
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-arm64
-        - krzko/otelcol-distributions/otelcol-gitlab:{{ .Version }}-ppc64le
 sboms:
     - id: archive
       artifacts: archive

--- a/distributions/googlecloudspanner/.goreleaser.yaml
+++ b/distributions/googlecloudspanner/.goreleaser.yaml
@@ -62,7 +62,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-386
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-386
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -79,7 +78,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-amd64
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-amd64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -96,7 +94,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-arm64
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-arm64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -113,7 +110,6 @@ dockers:
       dockerfile: Dockerfile
       image_templates:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-ppc64le
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-ppc64le
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -132,12 +128,6 @@ docker_manifests:
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-amd64
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-arm64
         - ghcr.io/krzko/otelcol-distributions/googlecloudspanner:{{ .Version }}-ppc64le
-    - name_template: krzko/otelcol-googlecloudspanner:{{ .Version }}
-      image_templates:
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-386
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-amd64
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-arm64
-        - krzko/otelcol-distributions/otelcol-googlecloudspanner:{{ .Version }}-ppc64le
 sboms:
     - id: archive
       artifacts: archive


### PR DESCRIPTION
* Fix `gitubactions` otelcol config
* Remove Docker Hub tags, use only GHCR