### PR TITLE
feat: add filter to supported event types

### DIFF
--- a/distributions/githubactions/manifest.yaml
+++ b/distributions/githubactions/manifest.yaml
@@ -7,7 +7,7 @@ dist:
   otelcol_version: 0.98.0
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubactionsreceiver v0.1.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubactionsreceiver v0.2.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.98.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.98.0
 


### PR DESCRIPTION
Bumping Github Actions collector as it filters on supported event types, which are `workflow_run` and `workflow_job`